### PR TITLE
fix: load web component as module

### DIFF
--- a/shell/src/app/pages/mf-and-wc-page.component.ts
+++ b/shell/src/app/pages/mf-and-wc-page.component.ts
@@ -39,6 +39,7 @@ export class MfAndWcPageComponent implements AfterViewInit {
       if (document.querySelector(`script[data-wc-src="${src}"]`)) return resolve();
       const s = document.createElement('script');
       s.src = src;
+      s.type = 'module';
       s.async = true;
       s.setAttribute('data-wc-src', src);
       s.onload = () => resolve();


### PR DESCRIPTION
## Summary
- ensure dynamically loaded web component script executes as an ES module

## Testing
- `npm run -w shell build`


------
https://chatgpt.com/codex/tasks/task_e_6896ad1162a4832cb986e86e984e9df7