### PR TITLE
fix: inline styles to avoid import.meta error

### DIFF
--- a/remote-hybrid/angular.json
+++ b/remote-hybrid/angular.json
@@ -20,14 +20,15 @@
               "src/favicon.ico",
               "src/assets"
             ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "styles": [],
             "scripts": [],
             "tsConfig": "tsconfig.app.json",
             "extraWebpackConfig": "webpack.config.cjs"
           },
           "configurations": {
+            "development": {
+              "extractCss": true
+            },
             "mf": {
               "outputHashing": "none",
               "vendorChunk": true,
@@ -49,13 +50,16 @@
               "src/favicon.ico",
               "src/assets"
             ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "styles": [],
             "scripts": [],
             "tsConfig": "tsconfig.app.json",
             "extraWebpackConfig": "extra-webpack.wc.cjs",
             "outputHashing": "none"
+          },
+          "configurations": {
+            "development": {
+              "extractCss": true
+            }
           }
         },
         "serve": {

--- a/remote-hybrid/src/index.html
+++ b/remote-hybrid/src/index.html
@@ -5,6 +5,11 @@
     <title>Remote Hybrid (Standalone)</title>
     <base href="/">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      body{margin:0;font-family:system-ui;padding:16px}
+      .card{padding:16px;border:1px solid #ddd;border-radius:12px;display:block}
+      button{cursor:pointer}
+    </style>
   </head>
   <body>
     <app-root>Remote Hybrid</app-root>

--- a/remote-hybrid/src/styles.css
+++ b/remote-hybrid/src/styles.css
@@ -1,1 +1,0 @@
-body{margin:0;font-family:system-ui; padding:16px} .card{padding:16px;border:1px solid #ddd;border-radius:12px;display:block} button{cursor:pointer}

--- a/shell/angular.json
+++ b/shell/angular.json
@@ -20,15 +20,18 @@
               "src/favicon.ico",
               "src/assets"
             ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "styles": [],
             "scripts": [],
             "vendorChunk": true,
             "commonChunk": true,
             "namedChunks": true,
             "tsConfig": "tsconfig.app.json",
             "extraWebpackConfig": "webpack.config.cjs"
+          },
+          "configurations": {
+            "development": {
+              "extractCss": true
+            }
           }
         },
         "serve": {

--- a/shell/src/index.html
+++ b/shell/src/index.html
@@ -5,6 +5,12 @@
     <title>Shell (Standalone) - MF + WC</title>
     <base href="/">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      body{margin:0;font-family:system-ui;padding:16px}
+      .card{padding:16px;border:1px solid #ddd;border-radius:12px}
+      .grid{display:grid;gap:16px;grid-template-columns:1fr 1fr}
+      nav a{margin-right:12px}
+    </style>
   </head>
   <body>
     <app-root></app-root>

--- a/shell/src/styles.css
+++ b/shell/src/styles.css
@@ -1,1 +1,0 @@
-body{margin:0;font-family:system-ui; padding:16px} .card{padding:16px;border:1px solid #ddd;border-radius:12px} .grid{display:grid;gap:16px;grid-template-columns:1fr 1fr} nav a{margin-right:12px}


### PR DESCRIPTION
## Summary
- inline global styles in shell and remote apps
- drop style bundles from Angular build configs to prevent import.meta runtime error

## Testing
- `npm run -w shell build`
- `npm run -w remote-hybrid build:mf`


------
https://chatgpt.com/codex/tasks/task_e_6896aebfb188832cb09d128ac9e1f469